### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/google-react-pr.yml
+++ b/.github/workflows/google-react-pr.yml
@@ -40,7 +40,7 @@ jobs:
         ./prepare.sh
 
     - name: Build Testhost Container
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: pathcheck/safeplaces-testhost
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -53,7 +53,7 @@ jobs:
     
 
     - name: Build Frontend Container
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: pathcheck/safeplaces-frontend
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore